### PR TITLE
support for uuid data type column in search

### DIFF
--- a/lib/Yancy/Backend/Dbic.pm
+++ b/lib/Yancy/Backend/Dbic.pm
@@ -399,6 +399,9 @@ sub _map_type {
     elsif ( $db_type =~ /(?:blob|bytea)/i ) {
         %conf = ( %conf, type => 'string', format => 'binary' );
     }
+    elsif ( $db_type =~ /(?:uuid)/i ) {
+        %conf = ( %conf, type => 'string', format => 'uuid' );
+    }
     else {
         # Default to string
         %conf = ( %conf, type => 'string' );

--- a/lib/Yancy/Controller/Yancy.pm
+++ b/lib/Yancy/Controller/Yancy.pm
@@ -1272,8 +1272,12 @@ sub _get_list_args {
     for my $key ( @{ $c->req->params->names } ) {
         next unless exists $props->{ $key };
         my $type = $props->{$key}{type} || 'string';
+        my $format = $props->{$key}{format} // '' ;
         my $value = $c->param( $key );
-        if ( is_type( $type, 'string' ) ) {
+        if ( is_type( $type, 'string' ) && $format eq 'uuid' ) {
+            $param_filter{ $key } = $value ;
+        } 
+        elsif ( is_type( $type, 'string' ) ) {
             if ( ( $value =~ tr/*/%/ ) <= 0 ) {
                  $value = "\%$value\%";
             }


### PR DESCRIPTION
currently uuid columns are typed as string with no particular format. However uuid strings stored in
uuid data types in databases does not support the
like operator. It is better to use '=' operator for the uuid columns for a functional match.